### PR TITLE
Contribuição | getErrorMessage

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,9 @@ function login() {
 
 function getErrorMessage(error) {
     if (error.code == "auth/user-not-found") {
-        return "Usuário nao encontrado";
+        return "Usuário não encontrado";
+    } else if (error.code == "auth/wrong-password") {
+        return "Senha não confere";
     }
     return error.message;
 }


### PR DESCRIPTION
error.code  imprime "auth/user-not-found" para usuário não encontrado,  também "auth/wrong-password", quando a senha não confere.